### PR TITLE
docs(readme): 增加 PaperSpine 在线试用入口

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -14,6 +14,14 @@ PaperSpine is a motivation-driven paper and report writing skill suite for Codex
 
 It is designed for writing tasks where the target format matters: journal papers, conference papers, course or technical reports, reviews, and competition papers. The workflow asks the agent to learn the target scene and strong examples before writing, then records why each manuscript unit is planned or changed.
 
+## Try It Online
+
+Don't want to clone the repo, run `install.sh`, and restart Codex or Claude Code first? You can try a draft online: upload a paper draft, say whether it is a rewrite or a build-from-materials job and which venue you are targeting, and see the rewrite matrix and section blueprint PaperSpine produces. It is also easy to share with labmates — they just drop in their own draft to get results.
+
+[![Try PaperSpine on Socialistic](https://socialistic.ai/api/embed/paperspine-paper-rewrite-suite-1668ae?lang=en)](https://socialistic.ai/skill/paperspine-paper-rewrite-suite-1668ae?utm_source=github&utm_medium=readme&utm_campaign=paperspine&utm_content=badge)
+
+> The online entry is community-maintained; local installation below remains the source of truth.
+
 ## Repository Layout
 
 ```text

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@
 
 它适合目标格式很重要的写作任务：期刊论文、会议论文、课程或技术报告、综述、竞赛论文。它要求 agent 在写作前先学习目标场景和优秀样例，再记录每一个写作单元为什么这样规划或修改。
 
+## 在线试用
+
+不想先 clone 仓库、跑 `install.sh`、再重启 Codex 或 Claude Code？可以直接在线试一份初稿：上传论文草稿，说明是改写还是从材料建稿、目标投哪个期刊，即可看到 PaperSpine 给出的改写矩阵和 section blueprint。也方便直接发给同门，他们把草稿丢进去就能拿到结果。
+
+[![在 Socialistic 上试用 PaperSpine](https://socialistic.ai/api/embed/paperspine-paper-rewrite-suite-1668ae?lang=zh)](https://socialistic.ai/zh/skill/paperspine-paper-rewrite-suite-1668ae?utm_source=github&utm_medium=readme&utm_campaign=paperspine&utm_content=badge)
+
+> 在线入口由社区维护，本地安装仍以下文为准。
+
 ## 仓库结构
 
 ```text


### PR DESCRIPTION
承接 issue #10。给两份 README（中/英）的介绍段后各加了一个「在线试用 / Try It Online」小节，指向 Socialistic 上托管的 PaperSpine 入口。

意图是降低第一次试用的门槛：访客不用先 clone 仓库、跑 `install.sh`、再重启 Codex / Claude Code，点链接上传一份初稿、说清是改写还是从材料建稿、目标投哪个期刊，就能看到改写矩阵和 section blueprint，也方便直接发给同门试。

- 只动 README，未触碰 `dist/`、`src/`、安装脚本或任何 skill 逻辑。
- 在小节里注明「在线入口由社区维护，本地安装仍以下文为准」，避免和正式安装路径冲突。
- 注意到仓库当前处于「7 月初前暂停维护」状态，不急，方便时再看即可；如果觉得不合适直接关掉就好。